### PR TITLE
refactor(RHTAPWATCH-684): support multiple calls to odcs

### DIFF
--- a/generate_compose/odcs_compose_generator.py
+++ b/generate_compose/odcs_compose_generator.py
@@ -15,42 +15,33 @@ from .odcs_requester import ODCSRequester
 
 @click.command()
 @click.option(
-    "--compose-file-path",
-    help="Compose file target path (including filename).",
+    "--compose-dir-path",
+    help="Compose files target directory.",
     type=click.Path(path_type=Path),
     required=True,
 )
 @click.option(
-    "--container-yaml-path",
-    help="Path in which container yaml file is stored",
-    type=click.Path(path_type=Path),
-    required=True,
-)
-@click.option(
-    "--content-sets-yaml-path",
-    help="Path in which content_sets yaml file is stored",
+    "--compose-input-yaml-path",
+    help="Path in which inputs yaml is stored",
     type=click.Path(path_type=Path),
     required=True,
 )
 def main(
-    compose_file_path: Path,
-    container_yaml_path: Path,
-    content_sets_yaml_path: Path,
+    compose_dir_path: Path,
+    compose_input_yaml_path: Path,
 ):
     """
     Get inputs from container and content_sets YAMLs and relay them to an ODCS
     compose generator that will request a compose and store it in a TBD location.
     """
-    container_data: dict = yaml.safe_load(container_yaml_path.read_text())
-    content_sets_data: dict = yaml.safe_load(content_sets_yaml_path.read_text())
+    compose_inputs: dict = yaml.safe_load(compose_input_yaml_path.read_text())
 
     compose_generator = ComposeGenerator(
         configurations_generator=ODCSConfigurationsGenerator(
-            container_data=container_data,
-            content_sets_data=content_sets_data,
+            compose_inputs=compose_inputs,
         ),
         requestor=ODCSRequester(),
-        fetcher=ODCSFetcher(compose_file_path=compose_file_path),
+        fetcher=ODCSFetcher(compose_dir_path=compose_dir_path),
     )
     compose_generator()
 

--- a/generate_compose/odcs_configurations_generator.py
+++ b/generate_compose/odcs_configurations_generator.py
@@ -16,12 +16,10 @@ class ODCSConfigurationsGenerator(ComposeConfigurationsGenerator):
     """
     Generate odcs configurations based on container and content_sets YAMLs.
 
-    :param container_data: data loaded from container.yaml
-    :param content_sets_data: data loaded from content_sets.yaml
+    :param compose_inputs: data loaded from compose inputs yaml
     """
 
-    container_data: dict
-    content_sets_data: dict
+    compose_inputs: dict
 
     def __call__(self) -> ODCSConfigurations:
         raise NotImplementedError()

--- a/generate_compose/odcs_requester.py
+++ b/generate_compose/odcs_requester.py
@@ -10,7 +10,7 @@ class ODCSRequestReference(ComposeReference):
     Reference to a remotely-stored compose data
     """
 
-    compose_url: str
+    compose_urls: list[str]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Change the implementation of odcs-related code so it allows multiple requests to odcs to be called. This includes changing the input format from using container and content_sets yamls to using a yaml based on the the odcs python client architecture.