### PR TITLE
chore: test pylint with pylint-pytest plugin

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ responses = "*"
 types-requests = "*"
 odcs = {extras = ["client"], version = "*"}
 appstudio-tools = {file = ".", editable = true}
+pylint-pytest = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9ceb058b3cc1119bad053dfaf86fa2f7ba7aa67964e2c3977be26482e07c27fc"
+            "sha256": "4cc518113a30295ef5b1e827336f10dfb817a3eb68c975bb33dfa94d7c0b9380"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -606,6 +606,15 @@
             "index": "pypi",
             "markers": "python_full_version >= '3.8.0'",
             "version": "==3.0.3"
+        },
+        "pylint-pytest": {
+            "hashes": [
+                "sha256:5d687a2f4b17e85654fc2a8f04944761efb11cb15dc46d008f420c377b149151",
+                "sha256:7a38be02c014eb6d98791eb978e79ed292f1904d3a518289c6d7ac4fb4122e98"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.7"
         },
         "pytest": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages]
 find = {}
+
+[tool.pylint]
+load-plugins = ["pylint_pytest"]


### PR DESCRIPTION
Adds the pylint-pytest pylint plugin to help
differentiate between code-relevant and test-relevant issues when running pylint on test files.

more info available on pypi: https://pypi.org/project/pylint-pytest/