### PR TITLE
refactor: make the protocols odcs-oriented

### DIFF
--- a/generate_compose/compose_generator.py
+++ b/generate_compose/compose_generator.py
@@ -2,11 +2,12 @@
 from dataclasses import dataclass
 
 from .protocols import (
-    ComposeConfigurations,
     ComposeConfigurationsGenerator,
     ComposeFetcher,
-    ComposeReference,
     ComposeRequester,
+    ODCSComposesConfigs,
+    ODCSRequestReferences,
+    ODCSResultReference,
 )
 
 
@@ -18,18 +19,18 @@ class ComposeGenerator:
 
     :param configurations_generator: an object to generate the configurations used for
         requesting a new compose
-    :param requestor: an object to request a new composed
+    :param requester: an object to request a new composed
     :param fetcher: an object to fetch a compose once it's ready
     """
 
     configurations_generator: ComposeConfigurationsGenerator
-    requestor: ComposeRequester
+    requester: ComposeRequester
     fetcher: ComposeFetcher
 
-    def __call__(self) -> ComposeReference:
-        configs: ComposeConfigurations = self.configurations_generator()
-        request_reference: ComposeReference = self.requestor(configs=configs)
-        result_reference: ComposeReference = self.fetcher(
+    def __call__(self) -> ODCSResultReference:
+        configs: ODCSComposesConfigs = self.configurations_generator()
+        request_reference: ODCSRequestReferences = self.requester(configs=configs)
+        result_reference: ODCSResultReference = self.fetcher(
             request_reference=request_reference
         )
         return result_reference

--- a/generate_compose/odcs_compose_generator.py
+++ b/generate_compose/odcs_compose_generator.py
@@ -40,7 +40,7 @@ def main(
         configurations_generator=ODCSConfigurationsGenerator(
             compose_inputs=compose_inputs,
         ),
-        requestor=ODCSRequester(),
+        requester=ODCSRequester(),
         fetcher=ODCSFetcher(compose_dir_path=compose_dir_path),
     )
     compose_generator()

--- a/generate_compose/odcs_configurations_generator.py
+++ b/generate_compose/odcs_configurations_generator.py
@@ -1,28 +1,7 @@
 """Configurations generator for ODCS compose"""
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
-from odcs.client.odcs import ComposeSourceGeneric  # type: ignore
-
-from .protocols import ComposeConfigurations, ComposeConfigurationsGenerator
-
-
-@dataclass(frozen=True)
-class ODCSComposeConfig:
-    """
-    Configurations to be used for requesting an ODCS compose
-    """
-
-    spec: ComposeSourceGeneric
-    additional_args: dict = field(default_factory=dict)
-
-
-@dataclass
-class ODCSComposesConfigs(ComposeConfigurations):
-    """
-    Configurations to be used for requesting multiple ODCS composes
-    """
-
-    configs: list[ODCSComposeConfig]
+from .protocols import ComposeConfigurationsGenerator, ODCSComposesConfigs
 
 
 @dataclass(frozen=True)
@@ -35,5 +14,5 @@ class ODCSConfigurationsGenerator(ComposeConfigurationsGenerator):
 
     compose_inputs: dict
 
-    def __call__(self) -> ComposeConfigurations:
+    def __call__(self) -> ODCSComposesConfigs:
         raise NotImplementedError()

--- a/generate_compose/odcs_fetcher.py
+++ b/generate_compose/odcs_fetcher.py
@@ -5,17 +5,7 @@ from pathlib import Path
 
 import requests
 
-from .odcs_requester import ODCSRequestReferences
-from .protocols import ComposeFetcher, ComposeReference
-
-
-@dataclass(frozen=True)
-class ODCSResultReference(ComposeReference):
-    """
-    Reference to locally-stored compose results
-    """
-
-    compose_dir_path: Path
+from .protocols import ComposeFetcher, ODCSRequestReferences, ODCSResultReference
 
 
 @dataclass(frozen=True)
@@ -28,7 +18,7 @@ class ODCSFetcher(ComposeFetcher):
 
     compose_dir_path: Path
 
-    def __call__(self, request_reference: ComposeReference) -> ODCSResultReference:
+    def __call__(self, request_reference: ODCSRequestReferences) -> ODCSResultReference:
         """
         Fetch the 'ODCS compose' from a remote reference.
 
@@ -39,7 +29,6 @@ class ODCSFetcher(ComposeFetcher):
         :return: The filesystem path to the downloaded ODCS compose file.
         """
         self.compose_dir_path.mkdir(parents=True, exist_ok=True)
-        assert isinstance(request_reference, ODCSRequestReferences)
         urls = request_reference.compose_urls
         for url in urls:
             with tempfile.NamedTemporaryFile(

--- a/generate_compose/odcs_requester.py
+++ b/generate_compose/odcs_requester.py
@@ -4,16 +4,7 @@ from dataclasses import dataclass
 from odcs.client.odcs import ODCS  # type: ignore
 
 from .odcs_configurations_generator import ODCSComposesConfigs
-from .protocols import ComposeConfigurations, ComposeReference, ComposeRequester
-
-
-@dataclass(frozen=True)
-class ODCSRequestReferences(ComposeReference):
-    """
-    Reference to a remotely-stored compose data
-    """
-
-    compose_urls: list[str]
+from .protocols import ComposeRequester, ODCSRequestReferences
 
 
 @dataclass(frozen=True)
@@ -25,8 +16,7 @@ class ODCSRequester(ComposeRequester):
 
     odcs: ODCS = ODCS("https://odcs.engineering.redhat.com/")
 
-    def __call__(self, compose_configs: ComposeConfigurations) -> ODCSRequestReferences:
-        assert isinstance(compose_configs, ODCSComposesConfigs)
+    def __call__(self, compose_configs: ODCSComposesConfigs) -> ODCSRequestReferences:
         composes = [
             self.odcs.request_compose(config.spec, **config.additional_args)
             for config in compose_configs.configs

--- a/generate_compose/protocols.py
+++ b/generate_compose/protocols.py
@@ -1,13 +1,30 @@
 """compose generator protocols"""
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Protocol
+
+from odcs.client.odcs import ComposeSourceGeneric  # type: ignore
 
 # pylint: disable=too-few-public-methods
 
 
-class ComposeConfigurations(Protocol):
+@dataclass(frozen=True)
+class ODCSComposeConfig:
     """
-    Data class for storing compose configurations
+    Configurations to be used for requesting an ODCS compose
     """
+
+    spec: ComposeSourceGeneric
+    additional_args: dict = field(default_factory=dict)
+
+
+@dataclass
+class ODCSComposesConfigs:
+    """
+    Configurations to be used for requesting multiple ODCS composes
+    """
+
+    configs: list[ODCSComposeConfig]
 
 
 class ComposeConfigurationsGenerator(Protocol):
@@ -15,14 +32,26 @@ class ComposeConfigurationsGenerator(Protocol):
     Generate compose configurations
     """
 
-    def __call__(self) -> ComposeConfigurations:
+    def __call__(self) -> ODCSComposesConfigs:
         pass
 
 
-class ComposeReference(Protocol):
+@dataclass(frozen=True)
+class ODCSRequestReferences:
     """
-    Data class for storing compose reference
+    Reference to remotely-stored compose requests
     """
+
+    compose_urls: list[str]
+
+
+@dataclass(frozen=True)
+class ODCSResultReference:
+    """
+    Reference to locally-stored compose results
+    """
+
+    compose_dir_path: Path
 
 
 class ComposeRequester(Protocol):
@@ -30,7 +59,7 @@ class ComposeRequester(Protocol):
     Given compose configurations, return a remote compose reference
     """
 
-    def __call__(self, configs: ComposeConfigurations) -> ComposeReference:
+    def __call__(self, configs: ODCSComposesConfigs) -> ODCSRequestReferences:
         pass
 
 
@@ -39,5 +68,5 @@ class ComposeFetcher(Protocol):
     Given remote compose reference, return a local compose reference
     """
 
-    def __call__(self, request_reference: ComposeReference) -> ComposeReference:
+    def __call__(self, request_reference: ODCSRequestReferences) -> ODCSResultReference:
         pass

--- a/tests/test_compose_generator.py
+++ b/tests/test_compose_generator.py
@@ -7,7 +7,6 @@ from generate_compose.compose_generator import ComposeGenerator
 from generate_compose.protocols import (
     ComposeConfigurationsGenerator,
     ComposeFetcher,
-    ComposeReference,
     ComposeRequester,
 )
 
@@ -39,10 +38,10 @@ class TestComposeGenerator:
         """Test ComposeGenerator call using mock dependencies"""
         compose_generator = ComposeGenerator(
             configurations_generator=mock_config_generator,
-            requestor=mock_requester,
+            requester=mock_requester,
             fetcher=mock_fetcher,
         )
-        out: ComposeReference = compose_generator()
+        out = compose_generator()
 
         mock_config_generator.assert_called_once_with()
         mock_requester.assert_called_once_with(

--- a/tests/test_odcs_compose_generator.py
+++ b/tests/test_odcs_compose_generator.py
@@ -93,7 +93,7 @@ class TestODCSComposeGenerator:
         mock_fetcher.assert_called_once_with(compose_dir_path=compose_dir_path)
         mock_compose_generator.assert_called_once_with(
             configurations_generator=mock_config_generator.return_value,
-            requestor=mock_requester.return_value,
+            requester=mock_requester.return_value,
             fetcher=mock_fetcher.return_value,
         )
         mock_compose_generator.return_value.assert_called_once_with()

--- a/tests/test_odcs_requester.py
+++ b/tests/test_odcs_requester.py
@@ -6,11 +6,12 @@ import pytest
 from odcs.client.odcs import ODCS, ComposeSourceGeneric  # type: ignore
 from requests.exceptions import HTTPError
 
-from generate_compose.odcs_configurations_generator import (
+from generate_compose.odcs_requester import ODCSRequester
+from generate_compose.protocols import (
     ODCSComposeConfig,
     ODCSComposesConfigs,
+    ODCSRequestReferences,
 )
-from generate_compose.odcs_requester import ODCSRequester, ODCSRequestReferences
 
 
 class TestODCSRequester:


### PR DESCRIPTION
At first, the protocols were non-odcs oriented, which required over-complicating the implementation in order to keep it generic.

Instead, we now make the protocols targeting odcs directly and keep only the implementation generic rather than the dataclasses that are passed around.