### PR TITLE
chore(RHTAPWATCH-633): Generate ODCS configurations

### DIFF
--- a/generate_compose/compose_generator.py
+++ b/generate_compose/compose_generator.py
@@ -29,7 +29,9 @@ class ComposeGenerator:
 
     def __call__(self) -> ODCSResultReference:
         configs: ODCSComposesConfigs = self.configurations_generator()
-        request_reference: ODCSRequestReferences = self.requester(configs=configs)
+        request_reference: ODCSRequestReferences = self.requester(
+            compose_configs=configs
+        )
         result_reference: ODCSResultReference = self.fetcher(
             request_reference=request_reference
         )

--- a/generate_compose/odcs_configurations_generator.py
+++ b/generate_compose/odcs_configurations_generator.py
@@ -1,4 +1,5 @@
 """Configurations generator for ODCS compose"""
+
 from dataclasses import dataclass
 
 from .protocols import ComposeConfigurationsGenerator, ODCSComposesConfigs
@@ -15,4 +16,8 @@ class ODCSConfigurationsGenerator(ComposeConfigurationsGenerator):
     compose_inputs: dict
 
     def __call__(self) -> ODCSComposesConfigs:
-        raise NotImplementedError()
+        """Generate odcs configurations based on composes request information.
+
+        :returns: an odcs configuration.
+        """
+        return ODCSComposesConfigs.from_list(self.compose_inputs["composes"])

--- a/generate_compose/odcs_requester.py
+++ b/generate_compose/odcs_requester.py
@@ -1,7 +1,7 @@
 """Request a new ODCS compose"""
 from dataclasses import dataclass
 
-from odcs.client.odcs import ODCS  # type: ignore
+from odcs.client.odcs import ODCS, AuthMech  # type: ignore
 
 from .odcs_configurations_generator import ODCSComposesConfigs
 from .protocols import ComposeRequester, ODCSRequestReferences
@@ -14,16 +14,20 @@ class ODCSRequester(ComposeRequester):
     to the remote compose location.
     """
 
-    odcs: ODCS = ODCS("https://odcs.engineering.redhat.com/")
+    odcs: ODCS = ODCS(
+        "https://odcs.engineering.redhat.com/", auth_mech=AuthMech.Kerberos
+    )
 
     def __call__(self, compose_configs: ODCSComposesConfigs) -> ODCSRequestReferences:
         composes = [
             self.odcs.request_compose(config.spec, **config.additional_args)
             for config in compose_configs.configs
         ]
-        for compose in composes:
-            self.odcs.wait_for_compose(compose["id"])
 
-        compose_urls = [compose["result_repofile"] for compose in composes]
+        finished_composes = [
+            self.odcs.wait_for_compose(compose["id"]) for compose in composes
+        ]
+
+        compose_urls = [compose["result_repofile"] for compose in finished_composes]
         req_refrences = ODCSRequestReferences(compose_urls=compose_urls)
         return req_refrences

--- a/tests/test_compose_generator.py
+++ b/tests/test_compose_generator.py
@@ -45,7 +45,7 @@ class TestComposeGenerator:
 
         mock_config_generator.assert_called_once_with()
         mock_requester.assert_called_once_with(
-            configs=mock_config_generator.return_value
+            compose_configs=mock_config_generator.return_value
         )
         mock_fetcher.assert_called_once_with(
             request_reference=mock_requester.return_value

--- a/tests/test_odcs_configurations_generator.py
+++ b/tests/test_odcs_configurations_generator.py
@@ -1,0 +1,265 @@
+"""Test odcs_configurations_generator.py"""
+
+import pytest
+from odcs.client.odcs import ComposeSourceBuild  # type: ignore
+from odcs.client.odcs import (
+    ComposeSourceModule,
+    ComposeSourcePulp,
+    ComposeSourceRawConfig,
+    ComposeSourceTag,
+)
+
+from generate_compose.odcs_configurations_generator import ODCSConfigurationsGenerator
+from generate_compose.protocols import ODCSComposeConfig, ODCSComposesConfigs
+
+
+@pytest.mark.parametrize(
+    "compose_inputs,expected_odcs_composes_configs",
+    [
+        pytest.param(
+            {
+                "composes": [
+                    {
+                        "spec": {
+                            "tag": "my-tag",
+                        },
+                        "kind": "ComposeSourceTag",
+                        "additional_args": {},
+                    },
+                    {
+                        "spec": {
+                            "modules": ["mod1", "mod2", "mod3"],
+                        },
+                        "kind": "ComposeSourceModule",
+                        "additional_args": {},
+                    },
+                    {
+                        "spec": {
+                            "content_sets": ["set1", "set2", "set3"],
+                        },
+                        "kind": "ComposeSourcePulp",
+                        "additional_args": {},
+                    },
+                    {
+                        "spec": {
+                            "config_name": "my-conf",
+                            "commit": "my-commit",
+                        },
+                        "kind": "ComposeSourceRawConfig",
+                        "additional_args": {},
+                    },
+                    {
+                        "spec": {
+                            "builds": ["build1", "build2"],
+                        },
+                        "kind": "ComposeSourceBuild",
+                        "additional_args": {},
+                    },
+                ]
+            },
+            ODCSComposesConfigs(
+                [
+                    ODCSComposeConfig(
+                        spec=ComposeSourceTag("my-tag"),
+                        additional_args={},
+                    ),
+                    ODCSComposeConfig(
+                        spec=ComposeSourceModule(["mod1", "mod2", "mod3"]),
+                        additional_args={},
+                    ),
+                    ODCSComposeConfig(
+                        spec=ComposeSourcePulp(["set1", "set2", "set3"]),
+                        additional_args={},
+                    ),
+                    ODCSComposeConfig(
+                        spec=ComposeSourceRawConfig("my-conf", "my-commit"),
+                        additional_args={},
+                    ),
+                    ODCSComposeConfig(
+                        spec=ComposeSourceBuild(["build1", "build2"]),
+                        additional_args={},
+                    ),
+                ]
+            ),
+            id="Composes of all types with mandatory inputs only",
+        ),
+        pytest.param(
+            {
+                "composes": [
+                    {
+                        "spec": {
+                            "tag": "t1",
+                            "packages": ["p1", "p2"],
+                            "builds": ["b1", "b2"],
+                            "sigkeys": ["s1", "s2"],
+                            "koji_event": 22,
+                            "modular_koji_tags": ["mkt1", "mkt2"],
+                            "module_defaults_url": "my-url",
+                            "module_defaults_commit": "my-commit",
+                            "scratch_modules": ["sm1", "sm2"],
+                        },
+                        "kind": "ComposeSourceTag",
+                        "additional_args": {},
+                    },
+                ]
+            },
+            ODCSComposesConfigs(
+                [
+                    ODCSComposeConfig(
+                        spec=ComposeSourceTag(
+                            "t1",
+                            packages=["p1", "p2"],
+                            builds=["b1", "b2"],
+                            sigkeys=["s1", "s2"],
+                            koji_event=22,
+                            modular_koji_tags=["mkt1", "mkt2"],
+                            module_defaults_url="my-url",
+                            module_defaults_commit="my-commit",
+                            scratch_modules=["sm1", "sm2"],
+                        ),
+                        additional_args={},
+                    ),
+                ]
+            ),
+            id="Compose of type tag with all named arguments",
+        ),
+        pytest.param(
+            {
+                "composes": [
+                    {
+                        "spec": {
+                            "modules": ["m1", "m2"],
+                            "sigkeys": ["s1", "s2"],
+                            "module_defaults_url": "my-url",
+                            "module_defaults_commit": "my-commit",
+                            "scratch_modules": ["sm1", "sm2"],
+                        },
+                        "kind": "ComposeSourceModule",
+                        "additional_args": {},
+                    },
+                ]
+            },
+            ODCSComposesConfigs(
+                [
+                    ODCSComposeConfig(
+                        spec=ComposeSourceModule(
+                            ["m1", "m2"],
+                            sigkeys=["s1", "s2"],
+                            module_defaults_url="my-url",
+                            module_defaults_commit="my-commit",
+                            scratch_modules=["sm1", "sm2"],
+                        ),
+                        additional_args={},
+                    ),
+                ]
+            ),
+            id="Compose of type module with all named arguments",
+        ),
+        pytest.param(
+            {
+                "composes": [
+                    {
+                        "spec": {
+                            "config_name": "my-conf",
+                            "commit": "my-commit",
+                            "koji_event": 22,
+                        },
+                        "kind": "ComposeSourceRawConfig",
+                        "additional_args": {},
+                    },
+                ]
+            },
+            ODCSComposesConfigs(
+                [
+                    ODCSComposeConfig(
+                        spec=ComposeSourceRawConfig(
+                            "my-conf",
+                            "my-commit",
+                            koji_event=22,
+                        ),
+                        additional_args={},
+                    ),
+                ]
+            ),
+            id="Compose of type raw-config with all named arguments",
+        ),
+        pytest.param(
+            {
+                "composes": [
+                    {
+                        "spec": {
+                            "builds": ["build1", "build2"],
+                            "sigkeys": ["s1", "s2"],
+                        },
+                        "kind": "ComposeSourceBuild",
+                        "additional_args": {},
+                    },
+                ]
+            },
+            ODCSComposesConfigs(
+                [
+                    ODCSComposeConfig(
+                        spec=ComposeSourceBuild(
+                            ["build1", "build2"],
+                            sigkeys=["s1", "s2"],
+                        ),
+                        additional_args={},
+                    ),
+                ]
+            ),
+            id="Compose of type build with all named arguments",
+        ),
+        pytest.param(
+            {
+                "composes": [
+                    {
+                        "spec": {
+                            "builds": ["build1"],
+                            "spec_kw_arg": "spec-kw-value",
+                            "another_spec_kw_arg": "another-spec-kw-value",
+                        },
+                        "kind": "ComposeSourceBuild",
+                        "additional_args": {
+                            "some_arg": "some-value",
+                            "another_arg": "another-value",
+                            "one_more_arg": "one-more-value",
+                        },
+                    },
+                ]
+            },
+            ODCSComposesConfigs(
+                [
+                    ODCSComposeConfig(
+                        spec=ComposeSourceBuild(
+                            ["build1"],
+                            spec_kw_arg="spec-kw-value",
+                            another_spec_kw_arg="another-spec-kw-value",
+                        ),
+                        additional_args={
+                            "some_arg": "some-value",
+                            "another_arg": "another-value",
+                            "one_more_arg": "one-more-value",
+                        },
+                    ),
+                ]
+            ),
+            id="Compose with source kwargs and additional arguments",
+        ),
+    ],
+)
+def test_odcs_configurations_generator(
+    compose_inputs: dict, expected_odcs_composes_configs: ODCSComposesConfigs
+) -> None:
+    """test ODCSConfigurationsGenerator.__call__"""
+    odcs_config_gen = ODCSConfigurationsGenerator(compose_inputs)
+    odcs_composes_configs = odcs_config_gen()
+    assert isinstance(odcs_composes_configs, ODCSComposesConfigs)
+    assert len(odcs_composes_configs.configs) == len(
+        expected_odcs_composes_configs.configs
+    )
+    for actual_composes, expected_composes in zip(
+        odcs_composes_configs.configs, expected_odcs_composes_configs.configs
+    ):
+        assert actual_composes.spec.source == expected_composes.spec.source
+        assert isinstance(actual_composes.spec, type(expected_composes.spec))
+        assert actual_composes.additional_args == expected_composes.additional_args

--- a/tests/test_odcs_requester.py
+++ b/tests/test_odcs_requester.py
@@ -35,6 +35,10 @@ class TestODCSRequester:
                 mock.request_compose.side_effect = HTTPError
             else:
                 mock.request_compose.side_effect = [
+                    {"result_repofile": "arbitrary-temp-value", "id": i}
+                    for i in range(1, num_of_composes + 1)
+                ]
+                mock.wait_for_compose.side_effect = [
                     {"result_repofile": f"{compose_url}", "id": i}
                     for i in range(1, num_of_composes + 1)
                 ]


### PR DESCRIPTION
Generate configurations to be used to request an ODCS compose,
using parameters from a yaml file.

Also fixed a few minor bugs, as the added functionality allowed testing
the process end to end for the first time.