### PR TITLE
fix(RHTAPWATCH-688): identify compose failures

### DIFF
--- a/generate_compose/odcs_requester.py
+++ b/generate_compose/odcs_requester.py
@@ -28,6 +28,21 @@ class ODCSRequester(ComposeRequester):
             self.odcs.wait_for_compose(compose["id"]) for compose in composes
         ]
 
+        failed_composes = [
+            compose for compose in finished_composes if compose["state_name"] != "done"
+        ]
+
+        if failed_composes:
+            failures = [
+                f"{compose['id']}: state={compose['state_name']} "
+                f"reason={compose['state_reason']}"
+                for compose in failed_composes
+            ]
+            sep = "\n"
+            raise RuntimeError(
+                f"Failed to generate some composes:\n{sep.join(failures)}"
+            )
+
         compose_urls = [compose["result_repofile"] for compose in finished_composes]
         req_refrences = ODCSRequestReferences(compose_urls=compose_urls)
         return req_refrences


### PR DESCRIPTION
Previously, we only covered failures that caused exceptions. With this change, also detect composed that finish and indicate their failure inside the compose record.