### PR TITLE
chore(RHTAPWATCH-691): verify-rpms test to fail on unsigned RPMs

### DIFF
--- a/verify_rpms/rpm_verifier.py
+++ b/verify_rpms/rpm_verifier.py
@@ -72,28 +72,27 @@ def get_unsigned_rpms(rpmdb: Path, runner: Callable = run) -> list[str]:
     ]
 
 
-def generate_output(
-    processed_images: Iterable[ProcessedImage], fail_unsigned: bool
-) -> tuple[bool, str]:
+def generate_output(processed_images: Iterable[ProcessedImage]) -> tuple[bool, str]:
     """
     Generate the output that should be printed to the user based on the processed images
-    and decide whether the script should fail or not
+    results.
 
     :param processed_images: each element contains a name and a list of unsigned images
-    :param fail_unsigned: whether the script should fail in case unsigned rpms found
+
+    :returns: The status and summary of the image processing.
     """
+    failures = True
     with_unsigned_rpms = [img for img in processed_images if img.unsigned_rpms]
     with_error = [img for img in processed_images if img.error]
     if not with_unsigned_rpms and not with_error:
         output = "No unsigned RPMs found."
-        fail = False
+        failures = False
     else:
         output = "\n".join([str(img) for img in with_unsigned_rpms])
         output = f"Found unsigned RPMs:\n{output}" if with_unsigned_rpms else ""
         error_str = "\n".join([f"{img.image}: {img.error}" for img in with_error])
         output = f"{output}\nEncountered errors:\n{error_str}" if error_str else output
-        fail = fail_unsigned
-    return fail, output.lstrip()
+    return failures, output.lstrip()
 
 
 def parse_image_input(image_input: str) -> list[str]:
@@ -146,7 +145,7 @@ class ImageProcessor:
 )
 @click.option(
     "--fail-unsigned",
-    help="Exit with failure if unsigned RPMs found",
+    help="Exit with failure if unsigned RPMs or other errors were found",
     type=bool,
     required=True,
 )
@@ -167,8 +166,8 @@ def main(img_input: str, fail_unsigned: bool, workdir: Path) -> None:
             processor, container_images
         )
 
-    fail, output = generate_output(list(processed_images), fail_unsigned)
-    if fail:
+    failures_occured, output = generate_output(list(processed_images))
+    if failures_occured and fail_unsigned:
         sys.exit(output)
     print(output)
 


### PR DESCRIPTION
The e2e test for the verify-rpms script checked
only a scenario where it should not fail when unsigned RPMs
or errors exists.

Adds tests for multiple scenarios - where the script should
and should not fail when encountering unsigned RPMs or other errors.

This lead to a refactor which changed the failing responsability
from which fails the process from "generate_output" to the
main function.