### PR TITLE
fix(RHTAPWATCH-694): snapshot should not have spec field

### DIFF
--- a/tests/test_rpm_verifier.py
+++ b/tests/test_rpm_verifier.py
@@ -198,20 +198,18 @@ def test_get_unsigned_rpms(test_input: list[str], expected: list[str]) -> None:
             dedent(
                 """
                 {
-                    "spec": {
-                        "application": "test",
-                        "components": [
-                            {
-                                "containerImage": "quay.io/container-image@sha256:123"
-                            },
-                            {
-                                "containerImage": "quay.io/container-image@sha256:456"
-                            },      
-                            {
-                                "containerImage": "quay.io/container-image@sha256:789"
-                            }
-                        ]
-                    }
+                    "application": "test",
+                    "components": [
+                        {
+                            "containerImage": "quay.io/container-image@sha256:123"
+                        },
+                        {
+                            "containerImage": "quay.io/container-image@sha256:456"
+                        },
+                        {
+                            "containerImage": "quay.io/container-image@sha256:789"
+                        }
+                    ]
                 }
                 """
             ).strip(),

--- a/verify_rpms/rpm_verifier.py
+++ b/verify_rpms/rpm_verifier.py
@@ -106,9 +106,7 @@ def parse_image_input(image_input: str) -> list[str]:
         snapshot = loads(s=image_input)
     except JSONDecodeError:
         return [image_input]
-    components = snapshot["spec"]["components"]
-    container_images = [component["containerImage"] for component in components]
-    return container_images
+    return [component["containerImage"] for component in snapshot["components"]]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The code was expecting snapshot objects to be encapsulated inside a spec field, but this is not the case.