### PR TITLE
fix: add extensions to generated repofiles

### DIFF
--- a/generate_compose/odcs_fetcher.py
+++ b/generate_compose/odcs_fetcher.py
@@ -32,7 +32,7 @@ class ODCSFetcher(ComposeFetcher):
         urls = request_reference.compose_urls
         for url in urls:
             with tempfile.NamedTemporaryFile(
-                delete=False, dir=self.compose_dir_path
+                delete=False, dir=self.compose_dir_path, suffix=".repo"
             ) as compose_path:
                 response = requests.get(url, timeout=10)
                 response.raise_for_status()

--- a/tests/test_odcs_fetcher.py
+++ b/tests/test_odcs_fetcher.py
@@ -57,5 +57,7 @@ def test_odcs_fetcher(tmp_path: Path, composes: list[str], urls: list[str]) -> N
     files_content = [
         p.read_text(encoding="utf-8") for p in out.compose_dir_path.iterdir()
     ]
+    extensions = [p.suffix for p in out.compose_dir_path.iterdir()]
 
     assert set(composes) == set(files_content)
+    assert set(extensions) == set([".repo"])


### PR DESCRIPTION
yum/dnf will only take into consideration files with .repo suffix. This change adds the suffix to the generated files.