### PR TITLE
chore(KONFLUX-887): show nicer output for missing compose input file

### DIFF
--- a/generate_compose/odcs_compose_generator.py
+++ b/generate_compose/odcs_compose_generator.py
@@ -34,7 +34,12 @@ def main(
     Get inputs from container and content_sets YAMLs and relay them to an ODCS
     compose generator that will request a compose and store it in a TBD location.
     """
-    compose_inputs: dict = yaml.safe_load(compose_input_yaml_path.read_text())
+    try:
+        compose_inputs: dict = yaml.safe_load(compose_input_yaml_path.read_text())
+    except FileNotFoundError as ex:
+        raise FileNotFoundError(
+            f"Could not find compose input file at {compose_input_yaml_path.resolve()}"
+        ) from ex
 
     compose_generator = ComposeGenerator(
         configurations_generator=ODCSConfigurationsGenerator(

--- a/tests/test_odcs_compose_generator.py
+++ b/tests/test_odcs_compose_generator.py
@@ -97,3 +97,25 @@ class TestODCSComposeGenerator:
             fetcher=mock_fetcher.return_value,
         )
         mock_compose_generator.return_value.assert_called_once_with()
+
+    def test_main_missing_input_file(  # pylint: disable=too-many-arguments
+        self,
+        compose_dir_path: Path,
+    ) -> None:
+        """Test call to odcs_compose_generator.py main function"""
+        input_yaml = Path("no/such/file")
+        with pytest.raises(FileNotFoundError) as ex:
+            odcs_compose_generator.main(  # pylint: disable=no-value-for-parameter
+                args=[
+                    "--compose-dir-path",
+                    str(compose_dir_path),
+                    "--compose-input-yaml-path",
+                    str(input_yaml),
+                ],
+                obj={},
+                standalone_mode=False,
+            )
+        assert (
+            str(ex.value)
+            == f"Could not find compose input file at {input_yaml.resolve()}"
+        )


### PR DESCRIPTION
Currently, if the input YAML is missing, a generic error exception will tell the file is missing. This change raises a clearer exception.