### PR TITLE
chore(RHTAPWATCH-717): update image references in tekton-tools

### DIFF
--- a/.tekton/tools-push.yaml
+++ b/.tekton/tools-push.yaml
@@ -396,7 +396,7 @@ spec:
         - name: SCRIPT
           value: |
             set -ex
-            grep -rl quay.io/redhat-user-workloads/rhtap-o11y-tenant/tools/tools:.* . | xargs sed -i s@quay.io/redhat-user-workloads/rhtap-o11y-tenant/tools/tools:.*@quay.io/redhat-user-workloads/rhtap-o11y-tenant/tools/tools:${REVISION}@gm
+            grep -rl quay.io/redhat-user-workloads/rhtap-o11y-tenant/tools/tools:.* . | xargs sed -i s@quay.io/redhat-user-workloads/rhtap-o11y-tenant/tools/tools:.*@quay.io/redhat-user-workloads/rhtap-o11y-tenant/tools/tools:$(params.REVISION)@gm
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
Automate update image references in `tekton-tools` when changes are merged in `tools`
- Add `update_private_repo.yaml` task to update private repositories
- Add a task to the push pipeline to create a PR in `tekton-tools`