### PR TITLE
fix: rpm signature identification

### DIFF
--- a/tests/test_rpm_verifier.py
+++ b/tests/test_rpm_verifier.py
@@ -85,7 +85,10 @@ def test_get_rpms_data(test_input: list[str], expected: list[str]) -> None:
         "rpm",
         "-qa",
         "--qf",
-        "%{NAME}-%{VERSION}-%{RELEASE} %{SIGPGP:pgpsig}\n",
+        (
+            "%{NAME}-%{VERSION}-%{RELEASE} "
+            + "%|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{(none)}|}|\n"
+        ),
         "--dbpath",
         "rpmdb_folder",
     ]

--- a/verify_rpms/rpm_verifier.py
+++ b/verify_rpms/rpm_verifier.py
@@ -70,7 +70,10 @@ def get_rpms_data(rpmdb: Path, runner: Callable = run) -> list[str]:
             "rpm",
             "-qa",
             "--qf",
-            "%{NAME}-%{VERSION}-%{RELEASE} %{SIGPGP:pgpsig}\n",
+            (
+                "%{NAME}-%{VERSION}-%{RELEASE} "
+                + "%|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{(none)}|}|\n"  # pylint: disable=line-too-long
+            ),
             "--dbpath",
             str(rpmdb),
         ],


### PR DESCRIPTION
The old format string here would miss key ids from epel and other sources.