### PR TITLE
chore(KFLUXVNGD-193): add helm to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ADD --chown=root:root --chmod=644 data/ca-trust/* /etc/pki/ca-trust/source/ancho
 RUN /usr/bin/fix-permissions /tmp/src \
     && /usr/bin/update-ca-trust
 RUN yum install -y krb5-workstation skopeo
+RUN curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 COPY data/kerberos/krb5.conf /etc
 
 USER 1001


### PR DESCRIPTION
We need Helm cli installed on an image so we can use for releasing Helm charts. Let's piggyback on this image for now.